### PR TITLE
Fix app hang and precision issue.

### DIFF
--- a/shaders/shader.rgen
+++ b/shaders/shader.rgen
@@ -9,7 +9,7 @@
 // INPUTS
 layout(binding = 0, rgba8) uniform image2D renderTarget;
 layout(binding = 1) uniform accelerationStructureEXT accelerationStructure;
-layout(binding = 3, rgba16_snorm) uniform image2D summedPixelColorImage;
+layout(binding = 3, rgba32f) uniform image2D summedPixelColorImage;
 layout(binding = 4) uniform RenderCallInfo {
     uint number;
     uint totalRenderCalls;
@@ -44,15 +44,17 @@ void main() {
 
     vec3 summedPixelColor = imageLoad(summedPixelColorImage, ivec2(gl_LaunchIDEXT.xy)).rgb;
 
+    dvec3 sum = summedPixelColor;
     for (uint i = 0; i < samplesPerCall; i++) {
         const vec2 uv = vec2(gl_LaunchIDEXT.x + randomFloat(payload.seed), gl_LaunchIDEXT.y + randomFloat(payload.seed)) / size;
         const Ray ray = getCameraRay(viewport, uv);
-        summedPixelColor += calculateRayColor(ray) / float(renderCallInfo.totalSamples);
+        sum += calculateRayColor(ray);
     }
+    summedPixelColor = vec3(sum);
 
     imageStore(summedPixelColorImage, ivec2(gl_LaunchIDEXT.xy), vec4(summedPixelColor, 1.0f));
 
-    const vec3 pixelColor = sqrt(summedPixelColor * renderCallInfo.totalSamples / float(renderCallInfo.number * samplesPerCall));
+    const vec3 pixelColor = sqrt(summedPixelColor / float(renderCallInfo.number * samplesPerCall));
     imageStore(renderTarget, ivec2(gl_LaunchIDEXT.xy), vec4(pixelColor, 1.0f));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,16 @@
 #include <thread>
 #include <iostream>
 #include "vulkan.h"
+#include <string>
 
-int main() {
+int main(int argc, const char** argv) {
     // SETUP
-    const uint32_t renderCalls = 50000;
-    const uint32_t samples = 1000000;
+    uint32_t renderCalls = 50;
+    uint32_t samples = 10000;
+    if (argc == 3) {
+        std::from_chars(argv[1], argv[1] + strlen(argv[1]), samples);
+        std::from_chars(argv[2], argv[2] + strlen(argv[2]), renderCalls);
+    }
 
     VulkanSettings settings = {
             .windowWidth = 1920,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,8 @@
 
 int main() {
     // SETUP
-    const uint32_t renderCalls = 50;
-    const uint32_t samples = 10000;
+    const uint32_t renderCalls = 50000;
+    const uint32_t samples = 1000000;
 
     VulkanSettings settings = {
             .windowWidth = 1920,

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -92,12 +92,12 @@ void Vulkan::render(const RenderCallInfo &renderCallInfo) {
     auto semaphore = *semaphores.begin();
     semaphores.pop_front();
     semaphores.push_back(semaphore);
-    while (true)
-    {
-        if (auto [result, index] = device.acquireNextImageKHR(swapChain, UINT64_MAX, semaphore); result == vk::Result::eSuccess) {
+    if (auto [result, index] = device.acquireNextImageKHR(swapChain, UINT64_MAX, semaphore);
+        result == vk::Result::eSuccess || result == vk::Result::eSuboptimalKHR) {
             swapChainImageIndex = index;
-            break;
-        }
+    }
+    else {
+        throw std::runtime_error{ "failed to acquire next image" };
     }
 
     device.resetFences(fence);

--- a/src/vulkan.h
+++ b/src/vulkan.h
@@ -49,7 +49,7 @@ private:
     std::vector<vk::AabbPositionsKHR> aabbs;
 
     const vk::Format swapChainImageFormat = vk::Format::eR8G8B8A8Unorm;
-    const vk::Format summedPixelColorImageFormat = vk::Format::eR16G16B16A16Unorm;
+    const vk::Format summedPixelColorImageFormat = vk::Format::eR32G32B32A32Sfloat;
     const vk::ColorSpaceKHR colorSpace = vk::ColorSpaceKHR::eSrgbNonlinear;
     const vk::PresentModeKHR presentMode = vk::PresentModeKHR::eImmediate;
 


### PR DESCRIPTION
AcquireNextImage will return ```eSuboptimal``` when window is resized.
Fix precision issue that is obvious when samples > 1M.